### PR TITLE
fix(formatter): allow fractionalDigits of 0 without invoking the default

### DIFF
--- a/integration/formatter/createMoneyIntlFormatter.test.ts
+++ b/integration/formatter/createMoneyIntlFormatter.test.ts
@@ -48,5 +48,23 @@ describe("createMoneyIntlFormatter", () => {
       );
       expect(formattedValue).toEqual("$5.00");
     });
+
+    it("should respect the hideFractionIfZero option", () => {
+      const moneyWithFraction = { amount: 550, currency: "USD" };
+      const formattedValueWithFraction = createFormatter().format(
+        createMoney(moneyWithFraction),
+        "en-US",
+        { hideFractionIfZero: true }
+      );
+      expect(formattedValueWithFraction).toEqual("$5.50");
+
+      const moneyWithoutFraction = { amount: 500, currency: "USD" };
+      const formattedValueWithoutFraction = createFormatter().format(
+        createMoney(moneyWithoutFraction),
+        "en-US",
+        { hideFractionIfZero: true }
+      );
+      expect(formattedValueWithoutFraction).toEqual("$5");
+    });
   });
 });

--- a/packages/formatter/src/createMoneyIntlFormatter.ts
+++ b/packages/formatter/src/createMoneyIntlFormatter.ts
@@ -33,7 +33,8 @@ export function createMoneyIntlFormatterUnit(currencies: CurrencyUnitISO[]) {
 const defaultOptions: MoneyIntlOptions = {
   currencyDisplay: "symbol",
   useGrouping: true,
-  style: "currency"
+  style: "currency",
+  hideFractionIfZero: false
 };
 
 function format(
@@ -73,6 +74,10 @@ function format(
     formatted = `-${formatted}`;
   }
 
+  const hideFractionDigits =
+    mergedOptions.hideFractionIfZero &&
+    parseInt(valueBase) % Math.pow(10, subunit) === 0;
+
   const currency = money.getCurrency();
 
   return Number(formatted).toLocaleString(locale, {
@@ -80,13 +85,15 @@ function format(
     useGrouping: mergedOptions.useGrouping,
     style: mergedOptions.style,
     currencyDisplay: mergedOptions.currencyDisplay,
-    minimumFractionDigits:
-      mergedOptions.minimumFractionDigits !== undefined
-        ? mergedOptions.minimumFractionDigits
-        : decimalDigitsLength,
-    maximumFractionDigits:
-      mergedOptions.maximumFractionDigits !== undefined
-        ? mergedOptions.maximumFractionDigits
-        : decimalDigitsLength
+    minimumFractionDigits: hideFractionDigits
+      ? 0
+      : mergedOptions.minimumFractionDigits !== undefined
+      ? mergedOptions.minimumFractionDigits
+      : decimalDigitsLength,
+    maximumFractionDigits: hideFractionDigits
+      ? 0
+      : mergedOptions.maximumFractionDigits !== undefined
+      ? mergedOptions.maximumFractionDigits
+      : decimalDigitsLength
   });
 }

--- a/packages/formatter/src/createMoneyIntlFormatter.ts
+++ b/packages/formatter/src/createMoneyIntlFormatter.ts
@@ -81,8 +81,12 @@ function format(
     style: mergedOptions.style,
     currencyDisplay: mergedOptions.currencyDisplay,
     minimumFractionDigits:
-      mergedOptions.minimumFractionDigits || decimalDigitsLength,
+      mergedOptions.minimumFractionDigits !== undefined
+        ? mergedOptions.minimumFractionDigits
+        : decimalDigitsLength,
     maximumFractionDigits:
-      mergedOptions.maximumFractionDigits || decimalDigitsLength
+      mergedOptions.maximumFractionDigits !== undefined
+        ? mergedOptions.maximumFractionDigits
+        : decimalDigitsLength
   });
 }

--- a/packages/formatter/src/types.ts
+++ b/packages/formatter/src/types.ts
@@ -6,6 +6,7 @@ export type MoneyIntlOptions = {
   maximumFractionDigits?: number;
   useGrouping?: boolean;
   style?: "currency" | "decimal";
+  hideFractionIfZero?: boolean;
 };
 
 export type MoneyIntlFormatter = {

--- a/website/docs/api/formatter/createMoneyIntlFormatter/Description.md
+++ b/website/docs/api/formatter/createMoneyIntlFormatter/Description.md
@@ -36,6 +36,7 @@ type MoneyIntlOptions = {
   maximumFractionDigits?: number;
   useGrouping?: boolean;
   style?: "currency" | "decimal";
+  hideFractionIfZero?: boolean;
 };
 
 ```


### PR DESCRIPTION
This is to allow the fractions to be set to 0.